### PR TITLE
Change the leading dim of B matrix to K

### DIFF
--- a/dgemm_blocked.c
+++ b/dgemm_blocked.c
@@ -19,7 +19,7 @@ void basic_dgemm(const int lda, const int M, const int N, const int K,
         for (j = 0; j < N; ++j) {
             double cij = C[j*lda+i];
             for (k = 0; k < K; ++k) {
-                cij += A[k*lda+i] * B[j*lda+k];
+                cij += A[k*lda+i] * B[j*K+k];
             }
             C[j*lda+i] = cij;
         }


### PR DESCRIPTION
Hi, it seems in the basic_gemm function. The leading dimension of matrix B is K instead of ida (i.e. M). I have tested the basic_gemm function and using lda as the leading dimension of matrix B leads to wrong results. Can you take a look? Thank you!